### PR TITLE
Refactor: Increase and unify frosted glass blur radius to 20px

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -8,8 +8,8 @@
   border-radius: 8px;
   box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
   background-color: rgba(255, 255, 255, 0.7); /* 半透明背景 */
-  backdrop-filter: blur(10px); /* 毛玻璃效果 */
-  -webkit-backdrop-filter: blur(10px); /* 兼容 Safari */
+  backdrop-filter: blur(20px); /* 毛玻璃效果 */
+  -webkit-backdrop-filter: blur(20px); /* 兼容 Safari */
   border: 1px solid rgba(255, 255, 255, 0.2); /* 可选：添加边框 */
 }
 /*所有页面实现毛玻璃特效*/
@@ -38,6 +38,7 @@ html[data-theme="light"] .search-dialog,
 html[data-theme="light"] #sidebar #sidebar-menus.open {
   background: rgba(255, 255, 255, 0.7);
   backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px); /* 兼容 Safari */
 }
 
 /* 深色模式 */
@@ -53,6 +54,7 @@ html[data-theme="dark"] .search-dialog,
 html[data-theme="dark"] #sidebar #sidebar-menus.open {
   background: rgba(0, 0, 0, 0.7);
   backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px); /* 兼容 Safari */
 }
 
 


### PR DESCRIPTION
Increased the blur radius for the #aplayer component from 10px to 20px to match other elements with a frosted glass effect.

Ensured that all components utilizing the backdrop-filter for frosted glass effects consistently use a 20px blur radius. This includes:
- #aplayer
- Various elements under #aside-content for both light and dark themes
- .layout > div:first-child:not(.recent-posts)
- #recent-posts > .recent-post-item
- #page-header.nav-visible #nav
- .search-dialog
- #sidebar #sidebar-menus.open

Additionally, added `-webkit-backdrop-filter: blur(20px);` to relevant rules in `css/custom.css` where it was missing, to ensure compatibility with Safari browsers for a consistent frosted glass appearance across different themes and components.