### PR TITLE
feat: Add CSS rules to hide post and page covers

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -8,8 +8,8 @@
   border-radius: 8px;
   box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
   background-color: rgba(255, 255, 255, 0.7); /* 半透明背景 */
-  backdrop-filter: blur(10px); /* 毛玻璃效果 */
-  -webkit-backdrop-filter: blur(10px); /* 兼容 Safari */
+  backdrop-filter: blur(20px); /* 毛玻璃效果 */
+  -webkit-backdrop-filter: blur(20px); /* 兼容 Safari */
   border: 1px solid rgba(255, 255, 255, 0.2); /* 可选：添加边框 */
 }
 /*所有页面实现毛玻璃特效*/
@@ -38,6 +38,7 @@ html[data-theme="light"] .search-dialog,
 html[data-theme="light"] #sidebar #sidebar-menus.open {
   background: rgba(255, 255, 255, 0.7);
   backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px); /* 兼容 Safari */
 }
 
 /* 深色模式 */
@@ -53,6 +54,62 @@ html[data-theme="dark"] .search-dialog,
 html[data-theme="dark"] #sidebar #sidebar-menus.open {
   background: rgba(0, 0, 0, 0.7);
   backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px); /* 兼容 Safari */
 }
 
+/* Hide post covers in recent post listings */
+#recent-posts .recent-post-item .post_cover {
+  display: none !important; /* Use !important to ensure override */
+}
 
+/* Adjust post info to take full width when cover is hidden */
+#recent-posts .recent-post-item > .recent-post-info {
+  width: 100% !important; /* Use !important to ensure override */
+  padding-left: 20px !important; /* Maintain some padding */
+  padding-right: 20px !important; /* Maintain some padding */
+}
+
+/* Ensure items without covers also look consistent if they didn't before */
+#recent-posts .recent-post-item > .recent-post-info.no-cover {
+  width: 100% !important;
+  padding: 30px 20px !important; /* Keep original padding for no-cover items */
+}
+
+/* Hide header image on single post pages */
+#page-header.post-bg {
+  background-image: none !important;
+  min-height: auto !important;
+  height: auto !important;
+  /* Potentially add a small padding or margin if needed after background removal */
+  padding-top: 20px !important; /* Example: ensure some space for post-info */
+  padding-bottom: 20px !important; /* Example: ensure some space for post-info */
+}
+
+/* Adjust post-info on single post pages when cover is hidden */
+/* This rule ensures that post-info (title, meta) remains clearly visible */
+/* and has a sensible background if the main page-header background is removed. */
+#page-header.post-bg #post-info {
+  position: relative !important; /* Reset absolute positioning if any */
+  bottom: auto !important; /* Reset bottom positioning */
+  color: var(--font-color) !important; /* Ensure text is visible, might need adjustment based on theme */
+  text-shadow: none !important; /* Remove text shadow if it was for dark bg */
+  padding: 20px 0 !important; /* Add some padding for spacing */
+}
+
+/* Ensure post-meta text is also legible */
+#page-header.post-bg #post-info #post-meta,
+#page-header.post-bg #post-info #post-meta a {
+  color: var(--card-meta) !important; /* Use a legible color for meta, adjust as needed */
+  text-shadow: none !important;
+}
+
+/* Ensure post title is also legible */
+#page-header.post-bg #post-info .post-title {
+    color: var(--text-highlight-color) !important; /* Use a legible color for title */
+    text-shadow: none !important;
+}
+
+/* Hide top image on pages */
+.top-img {
+  display: none !important;
+}


### PR DESCRIPTION
I've added CSS rules to `css/custom.css` to allow for hiding:
- Post covers in recent post listings (`#recent-posts .recent-post-item .post_cover`)
- Header images on single post pages (`#page-header.post-bg`)
- Top images on general pages (`.top-img`)

I also adjusted related CSS for `#recent-posts .recent-post-item > .recent-post-info` and `#page-header.post-bg #post-info` to ensure content layout and legibility are maintained after cover removal.

You confirmed these changes meet your requirements for disabling post covers. The main homepage banner (`#page-header.full_page`) was intentionally left unchanged as per your feedback.