### PR TITLE
Fix: Prevent image scaling in recent posts

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -267,6 +267,14 @@ template {
   -ms-transform: scale(1.1);
   transform: scale(1.1);
 }
+
+#recent-posts .recent-post-item .post_cover .post-bg:hover {
+  -webkit-transform: none !important;
+  -moz-transform: none !important;
+  -o-transform: none !important;
+  -ms-transform: none !important;
+  transform: none !important;
+}
 .postImgHover:hover .cover,
 .pagination-related:hover .cover {
   opacity: 0.5;


### PR DESCRIPTION
The issue involved images in the 'recent posts' section appearing to suddenly resize (变大变小) during scrolling.

This was likely due to an interaction between:
1. A CSS rule in `custom.css` intended to hide these images (`#recent-posts .recent-post-item .post_cover { display: none !important; }`).
2. A general CSS hover effect in `index.css` that scaled images (`.post-bg:hover { transform: scale(1.1); }`).

If the images became briefly visible (e.g., due to JavaScript or rendering quirks) while the hover effect was active or became active, it would cause the sudden resize.

The fix involves:
- Confirming no JavaScript directly overrides the `display: none`.
- Adding a more specific CSS rule in `index.css` to set `transform: none !important;` for `#recent-posts .recent-post-item .post_cover .post-bg:hover`. This ensures that even if these images become visible, they will not scale on hover, thus preventing the abrupt size change. The general hover scale effect for other images on the site remains unaffected.